### PR TITLE
chore: Add swp document reference in examples

### DIFF
--- a/examples/secure_cloud_function_bigquery_trigger/README.md
+++ b/examples/secure_cloud_function_bigquery_trigger/README.md
@@ -158,7 +158,3 @@ the resources of this module:
   * Compute Shared VPC Admin: `roles/compute.xpnAdmin`
 * Billing:
   * Billing User: `roles/billing.user`
-
-## Secure Web Proxy
-
-Please refer to [Secure Web Proxy documentation](../../docs/secure-web-proxy.md) for more details about pricing and how manually to delete.

--- a/examples/secure_cloud_function_bigquery_trigger/README.md
+++ b/examples/secure_cloud_function_bigquery_trigger/README.md
@@ -41,11 +41,13 @@ The resources and services that this example will create or enable are:
   * Create a VPC peering for the Shared VPC Network with:
     * A Compute Global Address
     * A Service Networking Connection
-  * Upload a example generated self-signed certificate to Certificate Manager
+  * Upload an example generated self-signed certificate to Certificate Manager
   * Create a Gateway Security Policy with:
     * A Gateway Security Policy Rule
     * A Security URL Lists resource
   * Create the Secure Web Proxy/Gateway (SWP/SWG) instance
+
+_Note: Please refer to [Secure Web Proxy documentation](../../docs/secure-web-proxy.md) for more details about pricing and how manually to delete it._
 
 * The **secure-cloud-serverless-security** module will:
   * Create KMS Keyring and Key for [customer managed encryption keys](https://cloud.google.com/run/docs/securing/using-cmek) in the **KMS Project** to be used by Cloud Function (2nd Gen)
@@ -156,3 +158,7 @@ the resources of this module:
   * Compute Shared VPC Admin: `roles/compute.xpnAdmin`
 * Billing:
   * Billing User: `roles/billing.user`
+
+## Secure Web Proxy
+
+Please refer to [Secure Web Proxy documentation](../../docs/secure-web-proxy.md) for more details about pricing and how manually to delete.

--- a/examples/secure_cloud_function_internal_server/README.md
+++ b/examples/secure_cloud_function_internal_server/README.md
@@ -169,7 +169,3 @@ A service account with the following roles must be used to provision the resourc
   * Compute Shared VPC Admin: `roles/compute.xpnAdmin`
 * Billing:
   * Billing User: `roles/billing.user`
-
-## Secure Web Proxy
-
-Please refer to [Secure Web Proxy documentation](../../docs/secure-web-proxy.md) for more details about pricing and how manually to delete.

--- a/examples/secure_cloud_function_internal_server/README.md
+++ b/examples/secure_cloud_function_internal_server/README.md
@@ -40,6 +40,8 @@ The resources and services that this example will create or enable are:
     * A Security URL Lists resource
   * Create the Secure Web Proxy/Gateway (SWP/SWG) instance
 
+_Note: Please refer to [Secure Web Proxy documentation](../../docs/secure-web-proxy.md) for more details about pricing and how manually delete it._
+
 * The **secure-cloud-serverless-security** module will:
   * Create KMS Keyring and Key for [customer managed encryption keys](https://cloud.google.com/run/docs/securing/using-cmek) in the **KMS Project** to be used by Cloud Function (2nd Gen)
   * Enable the following Organization Policies related to Cloud Function (2nd Gen) in the **Serverless Project**:
@@ -167,3 +169,7 @@ A service account with the following roles must be used to provision the resourc
   * Compute Shared VPC Admin: `roles/compute.xpnAdmin`
 * Billing:
   * Billing User: `roles/billing.user`
+
+## Secure Web Proxy
+
+Please refer to [Secure Web Proxy documentation](../../docs/secure-web-proxy.md) for more details about pricing and how manually to delete.

--- a/examples/secure_cloud_function_with_sql/README.md
+++ b/examples/secure_cloud_function_with_sql/README.md
@@ -41,6 +41,8 @@ The resources and services that this example will create or enable are:
     * A Security URL Lists resource
   * Create the Secure Web Proxy/Gateway (SWP/SWG) instance
 
+_Note: Please refer to [Secure Web Proxy documentation](../../docs/secure-web-proxy.md) for more details about pricing and how manually delete it._
+
 * The **secure-cloud-serverless-security** module will:
   * Create KMS Keyring and Key for [customer managed encryption keys](https://cloud.google.com/run/docs/securing/using-cmek) in the **KMS Project** to be used by Cloud Function (2nd Gen)
   * Enable the following Organization Policies related to Cloud Function (2nd Gen) in the **Serverless Project**:


### PR DESCRIPTION
Hello folks.

This PR is to insert the reference of the document that contains more details of secure web proxy in the examples.

