### PR TITLE
fix: Add instructions on Bigquery example

### DIFF
--- a/examples/secure_cloud_function_bigquery_trigger/README.md
+++ b/examples/secure_cloud_function_bigquery_trigger/README.md
@@ -155,7 +155,7 @@ INSERT INTO `<YOUR-PROJECT-ID>.dst_secure_cloud_function.tbl_test` VALUES
 * Go to the [Cloud Function console](https://console.cloud.google.com/functions)
 * Select your project and Cloud Function
 * Go to logs
-* When the insert is done, you can see the Cloud Function the logs with the buckets and regions at your Serverless project.
+* When the insert is done, you can see the logs with the buckets and regions at your Serverless Project Cloud Function Logs.
 
 ## Requirements
 

--- a/examples/secure_cloud_function_bigquery_trigger/README.md
+++ b/examples/secure_cloud_function_bigquery_trigger/README.md
@@ -129,6 +129,15 @@ _Note: Please refer to [Secure Web Proxy documentation](../../docs/secure-web-pr
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+To provision this example, run the following from within this directory:
+
+* `mv terraform.tfvars.example terraform.tfvars` to rename the example `tfvars` file.
+* Fill the `terraform.tfvars` with your values.
+* `terraform init` to get the plugins.
+* `terraform plan` to see the infrastructure plan.
+* `terraform apply` to apply the infrastructure build.
+* `terraform destroy` to destroy the built infrastructure.
+
 ## Requirements
 
 ### Software
@@ -140,7 +149,6 @@ The following dependencies must be available:
 * [Google Cloud SDK CLI](https://cloud.google.com/sdk/docs/install) > 428.0.0
 
 ### APIs
-#TODO: Fill with APIs needed on SA project
 
 ### Service Account
 

--- a/examples/secure_cloud_function_bigquery_trigger/README.md
+++ b/examples/secure_cloud_function_bigquery_trigger/README.md
@@ -140,7 +140,7 @@ To provision this example, run the following commands from within this directory
 
 ### Testing
 
-You can see the Secure Cloud Function running, doing a insert at Bigquery table.
+You can see the Secure Cloud Function running, doing an insert at Bigquery table.
 
 * Go to [BigQuery console](https://console.cloud.google.com/bigquery)
 * Select your Serverless project

--- a/examples/secure_cloud_function_bigquery_trigger/README.md
+++ b/examples/secure_cloud_function_bigquery_trigger/README.md
@@ -154,7 +154,7 @@ INSERT INTO `<YOUR-PROJECT-ID>.dst_secure_cloud_function.tbl_test` VALUES
 
 * Go to the [Cloud Function console](https://console.cloud.google.com/functions)
 * Select your Serverless project and Cloud Function
-* Go to logs
+* Go to the logs
 * When the insert is done, you can see the logs with the buckets and regions at your Serverless Project Cloud Function Logs.
 
 ## Requirements

--- a/examples/secure_cloud_function_bigquery_trigger/README.md
+++ b/examples/secure_cloud_function_bigquery_trigger/README.md
@@ -153,7 +153,7 @@ INSERT INTO `<YOUR-PROJECT-ID>.dst_secure_cloud_function.tbl_test` VALUES
 ```
 
 * Go to the [Cloud Function console](https://console.cloud.google.com/functions)
-* Select your project and Cloud Function
+* Select your Serverless project and Cloud Function
 * Go to logs
 * When the insert is done, you can see the logs with the buckets and regions at your Serverless Project Cloud Function Logs.
 

--- a/examples/secure_cloud_function_bigquery_trigger/README.md
+++ b/examples/secure_cloud_function_bigquery_trigger/README.md
@@ -129,7 +129,7 @@ _Note: Please refer to [Secure Web Proxy documentation](../../docs/secure-web-pr
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
-To provision this example, run the following from within this directory:
+To provision this example, run the following commands from within this directory:
 
 * `mv terraform.tfvars.example terraform.tfvars` to rename the example `tfvars` file.
 * Fill the `terraform.tfvars` with your values.
@@ -137,6 +137,25 @@ To provision this example, run the following from within this directory:
 * `terraform plan` to see the infrastructure plan.
 * `terraform apply` to apply the infrastructure build.
 * `terraform destroy` to destroy the built infrastructure.
+
+### Testing
+
+You can see the Secure Cloud Function running, doing a insert at Bigquery table.
+
+* Go to [BigQuery console](https://console.cloud.google.com/bigquery)
+* Select your Serverless project
+* Create a new Query
+* Run the following INSERT command
+
+```sql
+INSERT INTO `<YOUR-PROJECT-ID>.dst_secure_cloud_function.tbl_test` VALUES
+("AX","American Express","American Express","30006041298416","Gerson Beahan","688","09/2008","04/2013","26",9287,"77443")
+```
+
+* Go to the [Cloud Function console](https://console.cloud.google.com/functions)
+* Select your project and Cloud Function
+* Go to logs
+* When the insert is done, you can see the Cloud Function the logs with the buckets and regions at your Serverless project.
 
 ## Requirements
 
@@ -150,12 +169,24 @@ The following dependencies must be available:
 
 ### APIs
 
+### Required APIs enabled at Service Account project
+
+The service account project must have the following APIs enabled:
+
+* Access Context Manager API: `accesscontextmanager.googleapis.com`
+* Cloud Billing API: `cloudbilling.googleapis.com`
+* Cloud Build API: `cloudbuild.googleapis.com`
+* Cloud Key Management Service (KMS) API: `cloudkms.googleapis.com`
+* Cloud Pub/Sub API: `pubsub.googleapis.com`
+* Cloud Resource Manager API: `cloudresourcemanager.googleapis.com`
+* Identity and Access Management (IAM) API: `iam.googleapis.com`
+* Service Networking API: `servicenetworking.googleapis.com`
+
 ### Service Account
 
 A service account with the following roles must be used to provision
 the resources of this module:
 
-* Shared VPC Project
 * Organization Level
   * Access Context Manager Admin: `roles/accesscontextmanager.policyAdmin`
   * Organization Policy Admin: `roles/orgpolicy.policyAdmin`

--- a/examples/secure_cloud_function_bigquery_trigger/main.tf
+++ b/examples/secure_cloud_function_bigquery_trigger/main.tf
@@ -55,7 +55,7 @@ module "secure_harness" {
   ingress_policies                            = var.ingress_policies
   serverless_type                             = "CLOUD_FUNCTION"
   use_shared_vpc                              = true
-  time_to_wait_vpc_sc_propagation             = "600s"
+  time_to_wait_vpc_sc_propagation             = "630s"
 
   service_account_project_roles = {
     "prj-secure-cloud-function" = ["roles/eventarc.eventReceiver", "roles/viewer", "roles/compute.networkViewer", "roles/run.invoker"]

--- a/examples/secure_cloud_function_bigquery_trigger/terraform.tfvars.example
+++ b/examples/secure_cloud_function_bigquery_trigger/terraform.tfvars.example
@@ -1,0 +1,23 @@
+# /**
+#  * Copyright 2023 Google LLC
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *      http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+#  */
+
+billing_account                             = "000000-000000-000000"
+org_id                                      = "000000000000000000"
+folder_id                                   = "000000000000"
+create_access_context_manager_access_policy = false
+access_context_manager_policy_id            = "000000000000"
+access_level_members                        = ["user:email@email.com"]
+terraform_service_account                   = "ci-account@PROJECT.iam.gserviceaccount.com"


### PR DESCRIPTION
This PR adds the required APIs, how to provisioning the example and how the user can see the example working