### PR TITLE
feat: add build service account argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Functional examples are included in the
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | build\_env\_variables | User-provided build-time environment variables | `map(string)` | `null` | no |
+| build\_service\_account | Cloud Function Build Service Account Email. | `string` | `null` | no |
 | description | Short description of the function | `string` | `null` | no |
 | docker\_repository | User managed repository created in Artifact Registry optionally with a customer managed encryption key. | `string` | `null` | no |
 | entrypoint | The name of the function (as defined in source code) that will be executed. Defaults to the resource name suffix, if not specified | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Functional examples are included in the
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | build\_env\_variables | User-provided build-time environment variables | `map(string)` | `null` | no |
-| build\_service\_account | Cloud Function Build Service Account Email. | `string` | `null` | no |
+| build\_service\_account | Cloud Function Build Service Account Id. This is The fully-qualified name of the service account to be used for building the container. | `string` | `null` | no |
 | description | Short description of the function | `string` | `null` | no |
 | docker\_repository | User managed repository created in Artifact Registry optionally with a customer managed encryption key. | `string` | `null` | no |
 | entrypoint | The name of the function (as defined in source code) that will be executed. Defaults to the resource name suffix, if not specified | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "google_cloudfunctions2_function" "function" {
     runtime               = var.runtime
     entry_point           = var.entrypoint
     environment_variables = var.build_env_variables
-
+    service_account       = var.build_service_account
     source {
       dynamic "storage_source" {
         for_each = var.repo_source == null ? [var.storage_source] : []

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ resource "google_cloudfunctions2_function" "function" {
     entry_point           = var.entrypoint
     environment_variables = var.build_env_variables
     service_account       = var.build_service_account
+
     source {
       dynamic "storage_source" {
         for_each = var.repo_source == null ? [var.storage_source] : []

--- a/variables.tf
+++ b/variables.tf
@@ -155,3 +155,9 @@ variable "members" {
     error_message = "The supported keys are invokers and developers."
   }
 }
+
+variable "build_service_account" {
+  type        = string
+  description = "Cloud Function Build Service Account Email."
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -158,6 +158,6 @@ variable "members" {
 
 variable "build_service_account" {
   type        = string
-  description = "Cloud Function Build Service Account Email."
+  description = "Cloud Function Build Service Account Id. This is The fully-qualified name of the service account to be used for building the container."
   default     = null
 }


### PR DESCRIPTION
There are environments in which neither the Cloud Build Service Account nor the Compute Engine Service Account can be used, in these cases the user would need to specify a custom service account for running the builds. Currently the module does not support this argument. This PR adds the fields necessary to externalize the build service account argument.


References:
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudfunctions2_function#nested_build_config
https://github.com/GoogleCloudPlatform/terraform-google-cloud-functions/issues/129
https://github.com/terraform-google-modules/terraform-example-foundation/issues/1269