### PR TITLE
fix: provide default for `var.location` to improve backwards compatibility of ADC change.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,7 @@ variable "function_location" {
 variable "location" {
   description = "The location of this cloud function"
   type        = string
+  default     = null
 }
 
 variable "description" {


### PR DESCRIPTION
Currently, the logic was to use `var.function_location` if `var.location` was unset. But because `var.location` has no default, the `var.location is unset` scenario is impossible; terraform will ask for it to be set if this is the root module, and will error if this is a child module of the active configuration.

ref: https://github.com/terraform-google-modules/terraform-example-foundation/pull/1458